### PR TITLE
Add IconButton component with variants, sizes, and states

### DIFF
--- a/app/(pages)/components/icon-button/page.tsx
+++ b/app/(pages)/components/icon-button/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import Page from "@/app/components/ui/Page";
+import Centered from "@/app/components/ui/Centered";
+import ComponentSample from "@/app/components/ui/ComponentSample";
+import { edit } from "@/app/constants/icons";
+import { FC } from "react";
+import IconButton from "@/app/components/ui/IconButtonProps";
+
+const SizeGroup: FC<{
+  label: string;
+  icon: any; 
+  variant: "primary" | "secondary" | "tertiary";
+}> = ({ label, icon, variant }) => {
+  const variantProps = {
+    primary: variant === "primary",
+    secondary: variant === "secondary",
+    tertiary: variant === "tertiary",
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-sm text-gray-700 font-semibold">{label}</h3>
+      <div className="flex gap-4 justify-center flex-wrap">
+        <IconButton icon={edit} size="sm" tooltip="Small" {...variantProps} />
+        <IconButton icon={edit} size="md" tooltip="Medium" {...variantProps} />
+        <IconButton icon={edit} size="lg" tooltip="Large" {...variantProps} />
+      </div>
+    </div>
+  );
+};
+
+const IconButtonPage = () => {
+  return (
+    <Page title="Icon Button">
+      <Centered className="gap-y-8" direction="col" items="start">
+        {/* Estilos básicos */}
+        <div className="w-full">
+          <h2 className="text-lg font-bold mb-4">Variantes Básicas</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <ComponentSample label="Primary">
+              <div className="flex gap-4 justify-center flex-wrap">
+                <IconButton icon={edit} primary tooltip="Adicionar" />
+                <IconButton icon={edit} primary tooltip="Editar" />
+                <IconButton icon={edit} primary tooltip="Excluir" />
+              </div>
+            </ComponentSample>
+            
+            <ComponentSample label="Secondary">
+              <div className="flex gap-4 justify-center flex-wrap">
+                <IconButton icon={edit} secondary tooltip="Buscar" />
+                <IconButton icon={edit} secondary tooltip="Download" />
+                <IconButton icon={edit} secondary tooltip="Configurações" />
+              </div>
+            </ComponentSample>
+            
+            <ComponentSample label="Tertiary">
+              <div className="flex gap-4 justify-center flex-wrap">
+                <IconButton icon={edit} tertiary tooltip="Menu" />
+                <IconButton icon={edit} tertiary tooltip="Compartilhar" />
+                <IconButton icon={edit} tertiary tooltip="Favorito" />
+              </div>
+            </ComponentSample>
+          </div>
+        </div>
+
+        {/* Botões com diferentes tamanhos */}
+        <div className="w-full">
+          <h2 className="text-lg font-bold mb-4">Tamanhos</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <SizeGroup label="Primary" icon={edit} variant="primary" />
+            <SizeGroup label="Secondary" icon={edit} variant="secondary" />
+            <SizeGroup label="Tertiary" icon={edit} variant="tertiary" />
+          </div>
+        </div>
+
+        {/* Botões arredondados */}
+        <div className="w-full">
+          <h2 className="text-lg font-bold mb-4">Botões Arredondados</h2>
+          <ComponentSample label="Formato circular">
+            <div className="flex gap-4 justify-center flex-wrap">
+              <IconButton icon={edit} primary rounded tooltip="Adicionar" />
+              <IconButton icon={edit} secondary rounded tooltip="Editar" />
+              <IconButton icon={edit} tertiary rounded tooltip="Excluir" />
+            </div>
+          </ComponentSample>
+        </div>
+
+        {/* Estados */}
+        <div className="w-full">
+          <h2 className="text-lg font-bold mb-4">Estados</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <ComponentSample label="Disabled">
+              <div className="flex gap-4 justify-center flex-wrap">
+                <IconButton icon={edit} primary disabled tooltip="Adicionar (desabilitado)" />
+                <IconButton icon={edit} secondary disabled tooltip="Editar (desabilitado)" />
+                <IconButton icon={edit} tertiary disabled tooltip="Excluir (desabilitado)" />
+              </div>
+            </ComponentSample>
+          </div>
+        </div>
+      </Centered>
+    </Page>
+  );
+};
+
+export default IconButtonPage;

--- a/app/(pages)/components/icon-button/page.tsx
+++ b/app/(pages)/components/icon-button/page.tsx
@@ -1,15 +1,17 @@
 "use client";
 
+import { FC } from "react";
+import { StaticImport } from "next/dist/shared/lib/get-img-props";
+
 import Page from "@/app/components/ui/Page";
 import Centered from "@/app/components/ui/Centered";
 import ComponentSample from "@/app/components/ui/ComponentSample";
+import IconButton from "@/app/components/ui/IconButton";
 import { edit } from "@/app/constants/icons";
-import { FC } from "react";
-import IconButton from "@/app/components/ui/IconButtonProps";
 
 const SizeGroup: FC<{
   label: string;
-  icon: any; 
+  icon: StaticImport;
   variant: "primary" | "secondary" | "tertiary";
 }> = ({ label, icon, variant }) => {
   const variantProps = {
@@ -22,9 +24,9 @@ const SizeGroup: FC<{
     <div className="flex flex-col gap-2">
       <h3 className="text-sm text-gray-700 font-semibold">{label}</h3>
       <div className="flex gap-4 justify-center flex-wrap">
-        <IconButton icon={edit} size="sm" tooltip="Small" {...variantProps} />
-        <IconButton icon={edit} size="md" tooltip="Medium" {...variantProps} />
-        <IconButton icon={edit} size="lg" tooltip="Large" {...variantProps} />
+        <IconButton icon={icon} size="sm" tooltip="Small" {...variantProps} />
+        <IconButton icon={icon} size="md" tooltip="Medium" {...variantProps} />
+        <IconButton icon={icon} size="lg" tooltip="Large" {...variantProps} />
       </div>
     </div>
   );
@@ -45,7 +47,7 @@ const IconButtonPage = () => {
                 <IconButton icon={edit} primary tooltip="Excluir" />
               </div>
             </ComponentSample>
-            
+
             <ComponentSample label="Secondary">
               <div className="flex gap-4 justify-center flex-wrap">
                 <IconButton icon={edit} secondary tooltip="Buscar" />
@@ -53,7 +55,7 @@ const IconButtonPage = () => {
                 <IconButton icon={edit} secondary tooltip="Configurações" />
               </div>
             </ComponentSample>
-            
+
             <ComponentSample label="Tertiary">
               <div className="flex gap-4 justify-center flex-wrap">
                 <IconButton icon={edit} tertiary tooltip="Menu" />
@@ -92,9 +94,24 @@ const IconButtonPage = () => {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <ComponentSample label="Disabled">
               <div className="flex gap-4 justify-center flex-wrap">
-                <IconButton icon={edit} primary disabled tooltip="Adicionar (desabilitado)" />
-                <IconButton icon={edit} secondary disabled tooltip="Editar (desabilitado)" />
-                <IconButton icon={edit} tertiary disabled tooltip="Excluir (desabilitado)" />
+                <IconButton
+                  icon={edit}
+                  primary
+                  disabled
+                  tooltip="Adicionar (desabilitado)"
+                />
+                <IconButton
+                  icon={edit}
+                  secondary
+                  disabled
+                  tooltip="Editar (desabilitado)"
+                />
+                <IconButton
+                  icon={edit}
+                  tertiary
+                  disabled
+                  tooltip="Excluir (desabilitado)"
+                />
               </div>
             </ComponentSample>
           </div>

--- a/app/(pages)/components/page.tsx
+++ b/app/(pages)/components/page.tsx
@@ -12,6 +12,11 @@ const ComponentsPage = () => {
             Button
           </Typography>
         </Link>
+        <Link href="/components/icon-button">
+          <Typography className="text-xl text-[#0057FC] hover:underline">
+            IconButtonProps 
+          </Typography>
+        </Link>
       </Centered>
     </Page>
   );

--- a/app/(pages)/components/page.tsx
+++ b/app/(pages)/components/page.tsx
@@ -14,7 +14,7 @@ const ComponentsPage = () => {
         </Link>
         <Link href="/components/icon-button">
           <Typography className="text-xl text-[#0057FC] hover:underline">
-            IconButtonProps 
+            IconButton
           </Typography>
         </Link>
       </Centered>

--- a/app/components/ui/IconButton.tsx
+++ b/app/components/ui/IconButton.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import Image, { StaticImageData } from "next/image";
-import { twMerge } from "tailwind-merge";
-import Typography from "./Typography";
 import { ReactNode } from "react";
+import { StaticImport } from "next/dist/shared/lib/get-img-props";
+import Image from "next/image";
+import { twMerge } from "tailwind-merge";
 
-// Tipo para as props do IconButton
+import Typography from "./Typography";
+
 type IconButtonProps = {
-  icon: StaticImageData | string; // Aceita tanto importação estática quanto URL
+  icon: StaticImport | string; // Aceita tanto importação estática quanto URL
   label?: string | ReactNode;
   primary?: boolean;
   secondary?: boolean;
@@ -33,7 +34,6 @@ const IconButton = ({
   rounded,
   tooltip,
 }: IconButtonProps) => {
-  // Define tamanhos do botão baseado no prop size
   const sizeClasses = {
     sm: "h-8 w-8 p-1",
     md: "h-10 w-10 p-2",
@@ -44,7 +44,6 @@ const IconButton = ({
     <button
       className={twMerge(
         "group flex items-center justify-center transition-colors ease-in-out duration-200 hover:cursor-pointer",
-        // Variações de cores baseadas nos props
         primary
           ? "bg-[#0057FC] text-white hover:bg-[#0057FC]/90 border-0"
           : secondary
@@ -52,11 +51,8 @@ const IconButton = ({
           : tertiary
           ? "bg-white text-gray-700 border border-[#CED4DA] hover:bg-white/90"
           : "",
-        // Estado desabilitado
         disabled && "bg-[#E9ECEF] hover:bg-[#E9ECEF] hover:cursor-not-allowed",
-        // Tamanho do botão
         sizeClasses[size],
-        // Formato do botão (arredondado ou com cantos suaves)
         rounded ? "rounded-full" : "rounded-lg",
         className
       )}

--- a/app/components/ui/IconButtonProps.tsx
+++ b/app/components/ui/IconButtonProps.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import Image, { StaticImageData } from "next/image";
+import { twMerge } from "tailwind-merge";
+import Typography from "./Typography";
+import { ReactNode } from "react";
+
+// Tipo para as props do IconButton
+type IconButtonProps = {
+  icon: StaticImageData | string; // Aceita tanto importação estática quanto URL
+  label?: string | ReactNode;
+  primary?: boolean;
+  secondary?: boolean;
+  tertiary?: boolean;
+  className?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  size?: "sm" | "md" | "lg";
+  rounded?: boolean;
+  tooltip?: string;
+};
+
+const IconButton = ({
+  icon,
+  label,
+  primary,
+  secondary,
+  tertiary,
+  className,
+  onClick,
+  disabled,
+  size = "md",
+  rounded,
+  tooltip,
+}: IconButtonProps) => {
+  // Define tamanhos do botão baseado no prop size
+  const sizeClasses = {
+    sm: "h-8 w-8 p-1",
+    md: "h-10 w-10 p-2",
+    lg: "h-12 w-12 p-2.5",
+  };
+
+  return (
+    <button
+      className={twMerge(
+        "group flex items-center justify-center transition-colors ease-in-out duration-200 hover:cursor-pointer",
+        // Variações de cores baseadas nos props
+        primary
+          ? "bg-[#0057FC] text-white hover:bg-[#0057FC]/90 border-0"
+          : secondary
+          ? "bg-white text-[#0057FC] border border-[#0057FC] hover:bg-[#0057FC]/10"
+          : tertiary
+          ? "bg-white text-gray-700 border border-[#CED4DA] hover:bg-white/90"
+          : "",
+        // Estado desabilitado
+        disabled && "bg-[#E9ECEF] hover:bg-[#E9ECEF] hover:cursor-not-allowed",
+        // Tamanho do botão
+        sizeClasses[size],
+        // Formato do botão (arredondado ou com cantos suaves)
+        rounded ? "rounded-full" : "rounded-lg",
+        className
+      )}
+      onClick={onClick}
+      title={tooltip}
+      disabled={disabled}
+    >
+      <Image
+        src={icon}
+        alt={tooltip || "icon button"}
+        className={twMerge(
+          "transition-transform duration-200",
+          disabled ? "opacity-50" : "group-hover:scale-110"
+        )}
+        width={24}
+        height={24}
+      />
+
+      {label && (
+        <Typography
+          className={twMerge(
+            "ml-2 text-sm tracking-wider",
+            primary
+              ? "text-white"
+              : secondary
+              ? "text-[#0057FC]"
+              : tertiary
+              ? "text-gray-700"
+              : "",
+            disabled && "text-[#ADB5BD]"
+          )}
+        >
+          {label}
+        </Typography>
+      )}
+    </button>
+  );
+};
+
+export default IconButton;


### PR DESCRIPTION
This PR implements the IconButton component, supporting different variants (primary, secondary, tertiary), sizes (small, medium, large), and states (enabled/disabled), as well as rounded buttons and tooltip display.